### PR TITLE
Make sure Context sets required fields.

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -128,11 +128,23 @@ func (mux *Mux) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	// root is a special case because it is the top node in the tree
 	if req.URL.Path == slash || req.URL.Path == empty {
 		if nil != tr.handlers { // root match
-			(&Context{handler: -1, mux: mux, tree: tr}).Next()
+			(&Context{
+				handler:        -1,
+				mux:            mux,
+				tree:           tr,
+				ResponseWriter: res,
+				Request:        req,
+			}).Next()
 			return
 		} else if wild := tr.children[wildcard]; nil != wild {
 			// root level wildcard pattern match
-			(&Context{handler: -1, mux: mux, tree: wild}).Next()
+			(&Context{
+				handler:        -1,
+				mux:            mux,
+				tree:           wild,
+				ResponseWriter: res,
+				Request:        req,
+			}).Next()
 			return
 		}
 		http.NotFound(res, req)


### PR DESCRIPTION
While working on getting the [Go HTTP Routing Benchmark](https://github.com/julienschmidt/go-http-routing-benchmark)
to compile / run, an issue with the `bear` package was being observed.
Specifically, both the `http.ResponseWriter` and `*http.Request` sent
to the HandleFunc were set to `nil`. Upon digging in to the codebase
it was found that these two `Context{}` structs were being created
incorrectly.

It may be worth mentioning that I am not a user of `bear`, so I wouldn't
be able to determine whether these are the right changes to be making.
This should probably also have a regression test written for it.

Please let me know if any thing else is needed to merge this changeset.
